### PR TITLE
fix: 解决更新权限后无法触发页面更新的问题

### DIFF
--- a/src/models/useAccess.js
+++ b/src/models/useAccess.js
@@ -13,7 +13,7 @@
 import { useState } from 'react';
 import { createModel } from 'hox';
 // import useLoginModel from '@/models/useLogin';
-import _ from 'lodash';
+// import _ from 'lodash';
 
 const useAccess = () => {
   // const { isLogin, role, user, userId } = useLoginModel();
@@ -39,7 +39,7 @@ const useAccess = () => {
 
   // 已存在则覆盖。
   const updateAccess = (newAccess) => {
-    setAccess(_.merge(access, newAccess))
+    setAccess({ ...access, ...newAccess });
   }
 
   return { access, updateAccess }


### PR DESCRIPTION
之前的合并权限方法，权限对象地址没有变化，所以没有引起页面的更新，改为创建一个新的权限对象可以解决